### PR TITLE
Feat/tweak contrib style and event list

### DIFF
--- a/components/ContributionListItem.js
+++ b/components/ContributionListItem.js
@@ -22,7 +22,7 @@ class ContributionListItem extends React.Component {
         <View style={styles.listItem}>
           <Image
             source={{ uri }}
-            style={{width: '100%', height: 300, marginBottom: 10}}
+            style={styles.contributionMedia}
           />
           <Text style={[styles.baseText, styles.listItemLabel]}>{text}</Text>
           <Text style={[styles.baseText, styles.itemAuthor]}>{`${first} ${last}`}</Text>

--- a/components/ContributionListItem.js
+++ b/components/ContributionListItem.js
@@ -22,7 +22,7 @@ class ContributionListItem extends React.Component {
         <View style={styles.listItem}>
           <Image
             source={{ uri }}
-            style={{width: '100%', height: 300}}
+            style={{width: '100%', height: 300, marginBottom: 10}}
           />
           <Text style={[styles.baseText, styles.listItemLabel]}>{text}</Text>
           <Text style={[styles.baseText, styles.itemAuthor]}>{`${first} ${last}`}</Text>

--- a/components/Events.js
+++ b/components/Events.js
@@ -121,7 +121,7 @@ class Events extends React.Component {
             renderItem={({ item }) => (
               <Link to={`events/${item.id}`}>
                 <View style={styles.eventListItem}>
-                  <Text style={styles.baseText}>
+                  <Text style={[styles.baseText, styles.eventTitle]}>
                     <Text style={{ fontWeight: '600' }}>{item.title}</Text> &rarr; {item.firstName} {item.lastName}
                   </Text>
                 </View>

--- a/components/Notifications.js
+++ b/components/Notifications.js
@@ -23,7 +23,7 @@ class Notifications extends React.Component {
             return (
                 <Link to={inviteUrl}>
                   <View style={styles.eventListItem}>
-                  <Text style={styles.baseText}>
+                  <Text style={[styles.baseText, styles.eventTitle]}>
                      <Text style={{ fontWeight: '600' }}>{item.title}</Text> &rarr; {item.recipientFirstName} {item.recipientLastName}
                   </Text>
                 </View>

--- a/components/VideoContribution.js
+++ b/components/VideoContribution.js
@@ -37,7 +37,10 @@ class VideoContribution extends Component {
       : <Image source={{uri: playIcon}} style={styles.front} />;
 
     return (
-      <TouchableOpacity onPress={this.handleVideoTap}>
+      <TouchableOpacity
+        onPress={this.handleVideoTap}
+        style={{marginBottom: 10}}
+      >
         {icon}
         <Video
           source={{uri: this.props.url}}

--- a/styles/main.js
+++ b/styles/main.js
@@ -46,12 +46,15 @@ const main = StyleSheet.create({
     height: 44,
   },
   eventList: {
-    marginBottom: 20,
+    marginBottom: 30,
   },
   eventListItem: {
     flex: 1,
-    justifyContent: 'center',
-    height: 44,
+    justifyContent: 'center'
+  },
+  eventTitle: {
+    paddingTop: 8,
+    paddingBottom: 8
   },
   topic: {
     textAlign: 'center',
@@ -64,9 +67,9 @@ const main = StyleSheet.create({
     marginBottom: 10
   },
   h2: {
-    fontSize: 16,
+    fontSize: 18,
     fontWeight: 'bold',
-    lineHeight: 20,
+    lineHeight: 24,
     color: '#333'
   },
   baseText: {

--- a/styles/main.js
+++ b/styles/main.js
@@ -111,6 +111,12 @@ const main = StyleSheet.create({
   itemAuthor: {
     fontStyle: 'italic'
   },
+  contributionMedia: {
+    width: '100%',
+    height: 300,
+    marginBottom: 10,
+    borderRadius: 2
+  },
   button: {
     borderRadius: 100,
     backgroundColor: colors.brand,

--- a/styles/main.js
+++ b/styles/main.js
@@ -104,7 +104,9 @@ const main = StyleSheet.create({
   },
   listItemLabel: {
     marginTop: 3,
-    fontWeight: '500'
+    marginBottom: 5,
+    fontWeight: '500',
+    lineHeight: 22
   },
   itemAuthor: {
     fontStyle: 'italic'


### PR DESCRIPTION
1. slight line and space tweaks on text under media posts
1. improved spacing of event list items

# contrib before
<img width="380" alt="screen shot 2017-06-16 at 12 05 02 pm" src="https://user-images.githubusercontent.com/892749/27241070-1707ab64-528c-11e7-8484-6a55f1727be8.png">

# contrib after 
<img width="373" alt="screen shot 2017-06-16 at 11 59 22 am" src="https://user-images.githubusercontent.com/892749/27241073-1ac2f97a-528c-11e7-9e01-11817ea99fa4.png">

# event list before
<img width="372" alt="screen shot 2017-06-16 at 12 35 33 pm" src="https://user-images.githubusercontent.com/892749/27242089-63eb9fae-5290-11e7-939e-a7088e9b7bbd.png">

# event list after
<img width="382" alt="screen shot 2017-06-16 at 12 34 38 pm" src="https://user-images.githubusercontent.com/892749/27242107-73e86144-5290-11e7-8e3f-69e1ecd3eade.png">
